### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: go
+
+# Build with the lastest point releases of Go 1.5 and later
+go:
+  - 1.5.x
+  - 1.6.x
+  - 1.7.x
+  - 1.8.x
+  - 1.9.x
+  - 1.10.x
+  - stable
+
+install:
+  - go get -v ./...
+
+script:
+  - go build -v ./...
+  - go vet ./...

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/xaionaro-go/cryptoWallet.svg?branch=master)](https://travis-ci.org/xaionaro-go/cryptoWallet)
+
 Supported devices:
 
 | Vendor | Product | Vendor ID | Product ID | Version | Notes |

--- a/vendors/usbhid_devices.go
+++ b/vendors/usbhid_devices.go
@@ -27,5 +27,4 @@ func GetVendorId(vendorName string) uint16 {
 		return 0x534c
 	}
 	panic("unknown vendorName: " + vendorName)
-	return 0
 }


### PR DESCRIPTION
    Add .travis.yml and add the build status badge to the README.
    
    Example build on my fork: https://travis-ci.org/rfjakob/cryptoWallet/builds/394753550
    
    You will need to enable Travis on your repository on
    https://travis-ci.org/profile/xaionaro-go so that automatic builds
    and the status badge works.
    
    The Go versions that are built are the same that gocryptfs uses
    in its travis config.